### PR TITLE
Basic edits

### DIFF
--- a/benchmark-report.md
+++ b/benchmark-report.md
@@ -19,7 +19,7 @@ In this report we compare the performance of `odc-stac` ([GitHub](https://github
 
 ## Experiment Setup
 
-Experiment was conducted in the [Planetary Computer](https://planetarycomputer.microsoft.com/) Pangeo Notebook environment, using a single-node Dask cluster with 4 cores and 32 GiB RAM.
+Experiment was conducted in the [Planetary Computer](https://planetarycomputer.microsoft.com/) Pangeo Notebook environment, using a single-node Dask cluster with 4 cores and 32 GiB RAM per-worker.
 
 We load three bands (red, green and blue) in the native projection and resolution of the data (10m, UTM). We consider two scenarios: **deep** (temporal processing) and **wide** (building mosaic for visualisation).
 


### PR DESCRIPTION
Looks really good! A couple of edits in these two commits, and one or two questions:
- I changed the memory specification to be "per-worker" (9b3b8236b2c89ec386a962e2a0ad0fa0bb823691), but feel free to reject if that's not correct.
- In https://github.com/Kirill888/benchmark-report/compare/main...gadomski:edits?expand=1#diff-8ec00463d62e748b33db5ecbee84d235f75938bef6fbe4d8fff27ccb436e80b8R100, could you add some brief text about the feasibility/utility of adding similar caching behavior to **odc-stac**?

Really good stuff, thanks @Kirill888!